### PR TITLE
Add KC_DB_URL_DATABASE variable to Dockerfile and workflow

### DIFF
--- a/.github/workflows/openmemory-docker.yml
+++ b/.github/workflows/openmemory-docker.yml
@@ -112,6 +112,7 @@ jobs:
             GITHUB_SHA=${{ github.sha }}
             GITHUB_ACTOR=${{ github.actor }}
             GITHUB_WORKFLOW=${{ github.workflow }}
+            KC_DB_URL_DATABASE=${{ vars.KC_DB_URL_DATABASE }}
 
       - name: Output image digest
         run: echo "Image digest for ${{ matrix.service }} built successfully"

--- a/openmemory/keycloak/Dockerfile
+++ b/openmemory/keycloak/Dockerfile
@@ -1,16 +1,13 @@
-ARG KC_HOSTNAME
 ARG KC_LOG_LEVEL=INFO
-ARG KC_DB_URL_DATABASE
+ARG KC_DB_URL_DATABASE=keycloak
 # Keycloak OpenMemory Authentication Provider
 FROM quay.io/keycloak/keycloak:26.3.4
 
-ARG KC_HOSTNAME
+#ARG KC_HOSTNAME
 ARG KC_LOG_LEVEL
 # Set environment variables with defaults for development
 ENV KC_DB=postgres
-ENV KC_DB_URL_HOST=postgres
 ENV KC_DB_URL_DATABASE=${KC_DB_URL_DATABASE}
-ENV KC_HOSTNAME=${KC_HOSTNAME}
 ENV KC_HTTP_ENABLED=true
 ENV KC_HTTPS_ENABLED=true
 ENV KC_HTTP_PORT=8080


### PR DESCRIPTION
This pull request makes a minor update to the Keycloak Docker setup, focusing on how the `KC_DB_URL_DATABASE` environment variable is handled. The main change is to set a default value for `KC_DB_URL_DATABASE` in the Dockerfile and ensure this variable is passed from the GitHub Actions workflow.

Key changes:

**Dockerfile improvements:**

* Set a default value for the `KC_DB_URL_DATABASE` build argument in `openmemory/keycloak/Dockerfile`, simplifying local development and builds.

**CI/CD workflow updates:**

* Pass the `KC_DB_URL_DATABASE` variable from GitHub Actions workflow to the Docker build context in `.github/workflows/openmemory-docker.yml`.