### PR TITLE
Implementation/school law

### DIFF
--- a/.github/workflows/deployment-production.yml
+++ b/.github/workflows/deployment-production.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   deploy:
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'implementation/')) ||  github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: Production
     permissions:

--- a/.github/workflows/deployment-production.yml
+++ b/.github/workflows/deployment-production.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   deploy:
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'implementation/')) ||  github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'implementation/')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: Production
     permissions:


### PR DESCRIPTION
This pull request updates the deployment workflow configuration to restrict automatic deployments to only those workflow runs that originate from branches starting with `implementation/`. Manual deployments via workflow dispatch remain unaffected.

Deployment workflow restriction:

* [`.github/workflows/deployment-production.yml`](diffhunk://#diff-e715ac5247f13d47a37aa044f16787a991ec8752ac73626a350498a2870667e4L18-R18): Updated the deployment job condition to only trigger for successful workflow runs from branches prefixed with `implementation/`, in addition to manual triggers.