### PR TITLE
update prod deploy workflow - bugfix

### DIFF
--- a/.github/workflows/deployment-production.yml
+++ b/.github/workflows/deployment-production.yml
@@ -90,8 +90,8 @@ jobs:
             fi
             if [[ -n "$COMMIT_SHA" ]]; then
               # Latest successful run built from the same commit
-              RUN_ID=$(echo "$RUNS_JSON" | jq -r \
-                "map(select((.event==\"push\" or .event==\"workflow_dispatch\") and .conclusion==\"success\" and .head_sha==\"$COMMIT_SHA\")) | sort_by(.created_at) | last | .id // \"\"\")
+              RUN_ID=$(echo "$RUNS_JSON" | jq -r '
+                map(select((.event=="push" or .event=="workflow_dispatch") and .conclusion=="success" and .head_sha=="'"$COMMIT_SHA"'")) | sort_by(.created_at) | last | .id // ""')
             fi
           fi
 


### PR DESCRIPTION
This pull request makes a minor update to the `deployment-production.yml` workflow file to improve the way the `RUN_ID` is determined. The change adjusts the quoting in the `jq` command to correctly interpolate the `COMMIT_SHA` variable within the JSON query. 

* Improved variable interpolation in the `jq` command for extracting `RUN_ID` in `.github/workflows/deployment-production.yml` to ensure the `COMMIT_SHA` is correctly used in the query.