### PR TITLE
Update environment variables and API URLs for production readiness

### DIFF
--- a/openmemory/Makefile
+++ b/openmemory/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help up down logs shell migrate test test-clean env ui-install ui-start ui-dev ui-build ui-dev-start
 
 NEXT_PUBLIC_USER_ID=$(USER)
-NEXT_PUBLIC_API_URL=http://localhost:8765
+NEXT_PUBLIC_API_URL=https://mem0-api.jollybush-836e15bc.westus3.azurecontainerapps.io
 
 # Default target
 help:

--- a/openmemory/ui/.env.example
+++ b/openmemory/ui/.env.example
@@ -1,18 +1,18 @@
 # OpenMemory UI Environment Variables
 
 # NextAuth Configuration
-NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=your-32-character-random-secret-key
+#NEXTAUTH_URL=http://localhost:3000
+#NEXTAUTH_SECRET=your-32-character-random-secret-key
 
 # Keycloak Configuration
-KEYCLOAK_ID=openmemory-ui
-KEYCLOAK_SECRET=
-KEYCLOAK_ISSUER=http://localhost:8080/realms/openmemory
+#KEYCLOAK_ID=openmemory
+#KEYCLOAK_SECRET=
+#KEYCLOAK_ISSUER=http://localhost:8080/realms/compliance-theatre
 
 # API Configuration
-NEXT_PUBLIC_API_URL=http://localhost:8765
+NEXT_PUBLIC_API_URL=https://mem0-api.jollybush-836e15bc.westus3.azurecontainerapps.io
 NEXT_PUBLIC_USER_ID=default_user
 
 # Optional: Application Configuration
-NEXT_PUBLIC_APP_NAME=OpenMemory
-NEXT_PUBLIC_APP_DESCRIPTION=Memory Management Dashboard
+NEXT_PUBLIC_APP_NAME=school-law
+NEXT_PUBLIC_APP_DESCRIPTION=Compliance Theatre 2000

--- a/openmemory/ui/components/dashboard/Install.tsx
+++ b/openmemory/ui/components/dashboard/Install.tsx
@@ -46,12 +46,12 @@ export const Install = () => {
   const [copiedTab, setCopiedTab] = useState<string | null>(null);
   const user = process.env.NEXT_PUBLIC_USER_ID || "user";
 
-  const URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8765";
+  const URL = process.env.NEXT_PUBLIC_API_URL || "https://mem0-api.jollybush-836e15bc.westus3.azurecontainerapps.io";
 
   const handleCopy = async (tab: string, isMcp: boolean = false) => {
     const text = isMcp
-      ? `${URL}/mcp/openmemory/sse/${user}`
-      : `npx install-mcp i ${URL}/mcp/${tab}/sse/${user} --client ${tab}`;
+      ? `${URL}/mcp/openmemory/sse`
+      : `npx install-mcp i ${URL}/mcp/${tab}/sse --client ${tab}`;
 
     try {
       // Try using the Clipboard API first

--- a/openmemory/ui/hooks/useAppsApi.ts
+++ b/openmemory/ui/hooks/useAppsApi.ts
@@ -82,7 +82,7 @@ export const useAppsApi = (): UseAppsApiReturn => {
   const dispatch = useDispatch<AppDispatch>();
   const user_id = useSelector((state: RootState) => state.profile.userId);
 
-  const URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8765';
+  const URL = process.env.NEXT_PUBLIC_API_URL || 'https://mem0-api.jollybush-836e15bc.westus3.azurecontainerapps.io';
 
   const fetchApps = useCallback(
     async (

--- a/openmemory/ui/hooks/useConfig.ts
+++ b/openmemory/ui/hooks/useConfig.ts
@@ -33,7 +33,7 @@ export const useConfig = (): UseConfigApiReturn => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const dispatch = useDispatch<AppDispatch>();
-  const URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8765';
+  const URL = process.env.NEXT_PUBLIC_API_URL || 'https://mem0-api.jollybush-836e15bc.westus3.azurecontainerapps.io';
 
   const fetchConfig = async () => {
     setIsLoading(true);

--- a/openmemory/ui/hooks/useFiltersApi.ts
+++ b/openmemory/ui/hooks/useFiltersApi.ts
@@ -34,7 +34,7 @@ export const useFiltersApi = (): UseFiltersApiReturn => {
   const dispatch = useDispatch<AppDispatch>();
   const user_id = useSelector((state: RootState) => state.profile.userId);
 
-  const URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8765';
+  const URL = process.env.NEXT_PUBLIC_API_URL || 'https://mem0-api.jollybush-836e15bc.westus3.azurecontainerapps.io';
 
   const fetchCategories = useCallback(async (): Promise<void> => {
     setIsLoading(true);

--- a/openmemory/ui/hooks/useMemoriesApi.ts
+++ b/openmemory/ui/hooks/useMemoriesApi.ts
@@ -117,7 +117,7 @@ export const useMemoriesApi = (): UseMemoriesApiReturn => {
     (state: RootState) => state.memories.selectedMemory
   );
 
-  const URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8765';
+  const URL = process.env.NEXT_PUBLIC_API_URL || 'https://mem0-api.jollybush-836e15bc.westus3.azurecontainerapps.io';
 
   const fetchMemories = useCallback(
     async (

--- a/openmemory/ui/hooks/useStats.ts
+++ b/openmemory/ui/hooks/useStats.ts
@@ -36,7 +36,7 @@ export const useStats = (): UseMemoriesApiReturn => {
   const dispatch = useDispatch<AppDispatch>();
   const user_id = useSelector((state: RootState) => state.profile.userId);
 
-  const URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8765';
+  const URL = process.env.NEXT_PUBLIC_API_URL || 'https://mem0-api.jollybush-836e15bc.westus3.azurecontainerapps.io';
 
   const fetchStats = async () => {
     setIsLoading(true);

--- a/openmemory/ui/lib/api-client.ts
+++ b/openmemory/ui/lib/api-client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { getSession } from 'next-auth/react';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8765';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://mem0-api.jollybush-836e15bc.westus3.azurecontainerapps.io';
 
 // Create an axios instance
 const apiClient = axios.create({


### PR DESCRIPTION
This pull request updates the OpenMemory project to use a new production API endpoint, replacing all previous references to the local development server. It also updates some default UI environment variables and example configuration values to reflect new branding and deployment context.

**API Endpoint Migration:**
* All instances of the API URL in environment variables, configuration files, React hooks, and the API client are updated to use `https://mem0-api.jollybush-836e15bc.westus3.azurecontainerapps.io` instead of the previous `http://localhost:8765` development URL. [[1]](diffhunk://#diff-fbb69223c1e45a06930aadf33673636455a12c8e4c9dede458cdcdef98c0283bL4-R4) [[2]](diffhunk://#diff-4ade61e28bbdbdac494ab44572ad762ee19e1b01287d5372519342236c467b63L4-R18) [[3]](diffhunk://#diff-fc38fbda68bf45ae9ef635ce683005609248fcf122cc8f1d6b7b5bf0a94f32a6L49-R54) [[4]](diffhunk://#diff-efe39c1ed58e52de2d2281320032dc078fe49b62069249ca9b12c516cbd20c08L85-R85) [[5]](diffhunk://#diff-95f32fa5c7655a82b851dd8e8ceb0b948bd8ef270cb1ab654a0f38357a25717cL36-R36) [[6]](diffhunk://#diff-392139622c7945d3e392118d684d61111de4b9d80ee3d8e99b8f991881f30f30L37-R37) [[7]](diffhunk://#diff-90e3aeb87838b6c595e35577dcfdfe9837887793099c97e5aa36d5cee5b64527L120-R120) [[8]](diffhunk://#diff-efbf7bf0130df5843c2630070d5538b553c2298b95651b330d16bf2caef1ee2dL39-R39) [[9]](diffhunk://#diff-69db112c1c4f6b7d01c525c5fa1d97df50c87b15c3f291a0cc282e91e120a98cL4-R4)

**UI Environment and Branding Updates:**
* The `.env.example` file is updated: default values for `NEXT_PUBLIC_APP_NAME` and `NEXT_PUBLIC_APP_DESCRIPTION` now reflect "school-law" and "Compliance Theatre 2000", and example values for NextAuth and Keycloak are commented out or changed to match the new context.

**Install Component and API Usage Adjustments:**
* The `Install.tsx` component and several React hooks (`useAppsApi`, `useConfig`, `useFiltersApi`, `useMemoriesApi`, `useStats`) are updated to use the new API URL and, in the case of `Install.tsx`, to simplify the construction of certain URLs by removing the user ID from the endpoint path. [[1]](diffhunk://#diff-fc38fbda68bf45ae9ef635ce683005609248fcf122cc8f1d6b7b5bf0a94f32a6L49-R54) [[2]](diffhunk://#diff-efe39c1ed58e52de2d2281320032dc078fe49b62069249ca9b12c516cbd20c08L85-R85) [[3]](diffhunk://#diff-95f32fa5c7655a82b851dd8e8ceb0b948bd8ef270cb1ab654a0f38357a25717cL36-R36) [[4]](diffhunk://#diff-392139622c7945d3e392118d684d61111de4b9d80ee3d8e99b8f991881f30f30L37-R37) [[5]](diffhunk://#diff-90e3aeb87838b6c595e35577dcfdfe9837887793099c97e5aa36d5cee5b64527L120-R120) [[6]](diffhunk://#diff-efbf7bf0130df5843c2630070d5538b553c2298b95651b330d16bf2caef1ee2dL39-R39)

**API Client Update:**
* The Axios API client (`api-client.ts`) is updated to use the new production API endpoint by default.