### PR TITLE
feat: enhance configuration access control and add tests for mcp_tool…

### DIFF
--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -1,13 +1,13 @@
 from typing import Dict, Any, Optional
 from app.utils.client_config_factory import split_config
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 import logging
 from app.database import get_db
 from app.models import Config as ConfigModel
 from app.utils.memory import reset_memory_client
-from app.auth import get_current_user, get_user_record
+from app.auth import get_current_user, get_user_record, optional_auth
 from app.auth import require_admin
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind, Status, StatusCode
@@ -147,10 +147,10 @@ def get_default_config():
         "mem0": Mem0Config.model_validate(split.get("mem0", {}))
     }
 
-def get_saved_memory_config():
+def get_saved_memory_config(expand_secrets: bool = False):
     """Gets saved configuration formatted for the API and database."""
     from app.utils.client_config_factory import get_parsed_memory_config
-    source = get_parsed_memory_config(expandSecrets=False)
+    source = get_parsed_memory_config(expandSecrets=expand_secrets)
     split = split_config(source)    
     try:        
         parsed = ConfigSchema.model_validate(split)
@@ -159,11 +159,79 @@ def get_saved_memory_config():
         logger.error(f"Error validating configuration: {e}")
         raise HTTPException(status_code=500, detail="Invalid configuration format")    
 
+
+def _is_truthy(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+def _has_mcp_tool_write_access(current_user: Optional[Dict[str, Any]]) -> bool:
+    if not isinstance(current_user, dict):
+        return False
+
+    # Accept both RFC scope string and list-shaped claim variants.
+    scope_claim = current_user.get("scope") or current_user.get("scp") or ""
+    scopes: set[str] = set()
+    if isinstance(scope_claim, str):
+        scopes = set(scope_claim.split())
+    elif isinstance(scope_claim, list):
+        scopes = {str(scope).strip() for scope in scope_claim}
+    if "mcp_tool:write" in scopes:
+        return True
+
+    # Check Keycloak-like nested resource access claims.
+    resource_access = current_user.get("resource_access", {})
+    if isinstance(resource_access, dict):
+        for resource_data in resource_access.values():
+            if not isinstance(resource_data, dict):
+                continue
+            roles = resource_data.get("roles", [])
+            permissions = resource_data.get("permissions", [])
+            if isinstance(roles, list) and "mcp_tool:write" in roles:
+                return True
+            if isinstance(permissions, list) and "mcp_tool:write" in permissions:
+                return True
+    return False
+
+
+def _log_secrets_access_denial(current_user: Optional[Dict[str, Any]]) -> None:
+    auth_present = isinstance(current_user, dict)
+    logger.warning(
+        "Denied resolved config request without mcp_tool:write access",
+        extra={
+            "auth_present": auth_present,
+            "secrets_requested": True,
+            "required_access": "mcp_tool:write",
+        },
+    )
+
+    span = trace.get_current_span()
+    if span is not None:
+        span.set_attribute("mem0.config.secrets_requested", True)
+        span.set_attribute("mem0.config.secrets_authorized", False)
+        span.set_attribute("mem0.config.auth_present", auth_present)
+        span.add_event(
+            "config.secrets_access_denied",
+            {
+                "mem0.required_access": "mcp_tool:write",
+                "mem0.auth_present": auth_present,
+            },
+        )
+
 @router.get("/", response_model=ConfigSchema)
 @traced_endpoint("config.get")
-async def get_configuration(db: Session = Depends(get_db)):
+async def get_configuration(
+    secrets: Optional[str] = Query(default=None, include_in_schema=False),
+    db: Session = Depends(get_db),
+    current_user: Optional[Dict[str, Any]] = Depends(optional_auth),
+):
     """Get the current configuration."""
-    config = get_saved_memory_config()
+    secrets_requested = _is_truthy(secrets)
+    expand_secrets = secrets_requested and _has_mcp_tool_write_access(current_user)
+    if secrets_requested and not expand_secrets:
+        _log_secrets_access_denial(current_user)
+    config = get_saved_memory_config(expand_secrets=expand_secrets)
     if not config:
         # If no configuration exists, return the default configuration
         config = get_default_config()  

--- a/openmemory/api/app/routers/well_known_auth.py
+++ b/openmemory/api/app/routers/well_known_auth.py
@@ -69,7 +69,7 @@ async def oauth_protected_resource_metadata(resource_path: str = "") -> JSONResp
 		],
 
 		# Helpful discovery items for clients/resource servers
-		"scopes_supported": ["openid", "profile", "email", "offline_access", "mcp_tool", "mcp_tool:read"],
+		"scopes_supported": ["openid", "profile", "email", "offline_access", "mcp_tool", "mcp_tool:read", "mcp_tool:write"],
 		"response_types_supported": ["code", "token", "id_token"],
 		"grant_types_supported": ["authorization_code", "refresh_token", "client_credentials", "urn:ietf:params:oauth:grant-type:jwt-bearer"],
 	}

--- a/openmemory/api/tests/routers/test_config.py
+++ b/openmemory/api/tests/routers/test_config.py
@@ -1,0 +1,151 @@
+import pytest
+
+from app.routers import config as config_router
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, False),
+        ("", False),
+        ("false", False),
+        ("off", False),
+        ("0", False),
+        ("true", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("on", True),
+        ("1", True),
+    ],
+)
+def test_is_truthy(value, expected):
+    assert config_router._is_truthy(value) is expected
+
+
+def test_has_mcp_tool_write_access_from_scope():
+    token_claims = {"scope": "openid profile mcp_tool:write"}
+    assert config_router._has_mcp_tool_write_access(token_claims) is True
+
+
+def test_has_mcp_tool_write_access_from_resource_access_roles():
+    token_claims = {
+        "resource_access": {
+            "openmemory-api": {
+                "roles": ["mcp_tool:write"]
+            }
+        }
+    }
+    assert config_router._has_mcp_tool_write_access(token_claims) is True
+
+
+def test_has_mcp_tool_write_access_from_resource_access_permissions():
+    token_claims = {
+        "resource_access": {
+            "openmemory-api": {
+                "permissions": ["mcp_tool:write"]
+            }
+        }
+    }
+    assert config_router._has_mcp_tool_write_access(token_claims) is True
+
+
+def test_has_mcp_tool_write_access_missing_claim():
+    token_claims = {"scope": "openid mcp_tool:read"}
+    assert config_router._has_mcp_tool_write_access(token_claims) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "secrets,current_user,expected_expand",
+    [
+        (None, None, False),
+        ("false", {"scope": "openid mcp_tool:write"}, False),
+        ("true", None, False),
+        ("true", {"scope": "openid mcp_tool:read"}, False),
+        ("true", {"scope": "openid mcp_tool:write"}, True),
+        (
+            "1",
+            {"resource_access": {"openmemory-api": {"roles": ["mcp_tool:write"]}}},
+            True,
+        ),
+    ],
+)
+async def test_get_configuration_secrets_gate(monkeypatch, secrets, current_user, expected_expand):
+    captured = {}
+
+    def _fake_get_saved_memory_config(expand_secrets=False):
+        captured["expand_secrets"] = expand_secrets
+        return config_router.ConfigSchema.model_validate({"mem0": {"version": "v1.1"}})
+
+    monkeypatch.setattr(config_router, "get_saved_memory_config", _fake_get_saved_memory_config)
+
+    # Should not be called in this test path because get_saved_memory_config returns data.
+    monkeypatch.setattr(config_router, "get_default_config", lambda: pytest.fail("unexpected default config call"))
+
+    result = await config_router.get_configuration(
+        secrets=secrets,
+        db=None,
+        current_user=current_user,
+    )
+
+    assert captured["expand_secrets"] is expected_expand
+    assert result["mem0"]["version"] == "v1.1"
+
+
+@pytest.mark.asyncio
+async def test_get_configuration_denial_logs_and_traces(monkeypatch, caplog):
+    class _SpanStub:
+        def __init__(self):
+            self.attributes = {}
+            self.events = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def set_attribute(self, key, value):
+            self.attributes[key] = value
+
+        def add_event(self, name, attributes):
+            self.events.append((name, attributes))
+
+    class _TracerStub:
+        def __init__(self, span):
+            self._span = span
+
+        def start_as_current_span(self, *args, **kwargs):
+            return self._span
+
+    span = _SpanStub()
+
+    monkeypatch.setattr(config_router, "_TRACER", _TracerStub(span))
+    monkeypatch.setattr(config_router.trace, "get_current_span", lambda *args, **kwargs: span)
+    monkeypatch.setattr(
+        config_router,
+        "get_saved_memory_config",
+        lambda expand_secrets=False: config_router.ConfigSchema.model_validate({"mem0": {"version": "v1.1"}}),
+    )
+
+    with caplog.at_level("WARNING"):
+        result = await config_router.get_configuration(
+            secrets="true",
+            db=None,
+            current_user={"scope": "openid mcp_tool:read"},
+        )
+
+    assert result["mem0"]["version"] == "v1.1"
+    assert "Denied resolved config request without mcp_tool:write access" in caplog.text
+    assert span.attributes["mem0.config.secrets_requested"] is True
+    assert span.attributes["mem0.config.secrets_authorized"] is False
+    assert span.attributes["mem0.config.auth_present"] is True
+    assert span.events == [
+        (
+            "config.secrets_access_denied",
+            {
+                "mem0.required_access": "mcp_tool:write",
+                "mem0.auth_present": True,
+            },
+        )
+    ]

--- a/openmemory/api/tests/routers/test_well_known_auth.py
+++ b/openmemory/api/tests/routers/test_well_known_auth.py
@@ -1,0 +1,17 @@
+import pytest
+
+from app.routers import well_known_auth
+
+
+@pytest.mark.asyncio
+async def test_oauth_protected_resource_metadata_includes_mcp_tool_write(monkeypatch):
+    class _OpenIdStub:
+        def well_known(self):
+            return {}
+
+    monkeypatch.setattr(well_known_auth, "get_keycloak_openid", lambda: _OpenIdStub())
+
+    response = await well_known_auth.oauth_protected_resource_metadata()
+
+    assert response.status_code == 200
+    assert b'"mcp_tool:write"' in response.body


### PR DESCRIPTION
This pull request strengthens security around configuration secrets exposure and improves test coverage for authorization logic. The main change is that the `/config` API endpoint now only returns resolved secrets if the authenticated user has the `mcp_tool:write` scope or equivalent permissions. Several utility functions were added to support this logic, and comprehensive tests were introduced to ensure correct behavior. Additionally, the OAuth discovery metadata now advertises support for the new scope.

**Authorization and Secrets Handling:**

* The `get_configuration` endpoint in `config.py` now only returns resolved secrets if the user has `mcp_tool:write` access, using the new `_has_mcp_tool_write_access` and `_is_truthy` utility functions. Unauthorized requests for secrets are denied and logged, with tracing instrumentation for observability. [[1]](diffhunk://#diff-2c72f6733cfd2bc13c50d9e4d85cd700bf7a0983b58399183ec17184e886a67cL3-R10) [[2]](diffhunk://#diff-2c72f6733cfd2bc13c50d9e4d85cd700bf7a0983b58399183ec17184e886a67cL150-R153) [[3]](diffhunk://#diff-2c72f6733cfd2bc13c50d9e4d85cd700bf7a0983b58399183ec17184e886a67cR162-R234)
* The `/config` endpoint now accepts an optional `secrets` query parameter to control whether secrets should be expanded, gated by the above authorization logic.

**OAuth Metadata Update:**

* The OAuth2 `.well-known` endpoint now includes `mcp_tool:write` in the advertised supported scopes, making it discoverable for clients.

**Testing Improvements:**

* Added comprehensive tests for the new truthiness and authorization utility functions, and for the `/config` endpoint’s secrets gating logic, including logging and tracing behavior.
* Added a test to ensure the OAuth metadata endpoint advertises the new `mcp_tool:write` scope.… write access